### PR TITLE
Add's Pathologist Alt Title

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -149,6 +149,18 @@
 	satchel = /obj/item/weapon/storage/backpack/satchel_vir
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/vir
 	messengerbag = /obj/item/weapon/storage/backpack/messenger/viro
+	
+/datum/outfit/job/pharmacist/Pathologist
+	name = "Pathologist"
+	jobtype = /datum/job/pharmacist
+
+	uniform = /obj/item/clothing/under/rank/biochemist
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/biochemist
+
+	backpack = /obj/item/weapon/storage/backpack/virology
+	satchel = /obj/item/weapon/storage/backpack/satchel_vir
+	dufflebag = /obj/item/weapon/storage/backpack/duffel/vir
+	messengerbag = /obj/item/weapon/storage/backpack/messenger/viro
 
 /datum/job/psychiatrist
 	title = "Psychiatrist"


### PR DESCRIPTION
Adds a new Chemist alt title of Pathologist, meant to replace virologist while also taking on some more support related duties such as assisting in Autopsy

* Please describe the intent of your changes in a clear fashion.
* Please make sure that, in the case of mapping changes, you include images of these changes in the PR's description.
* Please make sure to mark your PR as wip or review required by making a comment with !wip or !review required

### IC changelog
`It is possible and encouraged (for changes that will have a larger impact on players) to write a ic changelog and add it to the PR description.
This changelog will be pushed to the newscasters when the PR is merged`